### PR TITLE
 Forwarder Encapsulation support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 mqtt-sn-pub
 mqtt-sn-sub
 mqtt-sn-serial-bridge
+mqtt-sn-pub.exe
+mqtt-sn-sub.exe
+mqtt-sn-serial-bridge.exe
 *.o
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supported Features
 - Manual and automatic client ID generation
 - Displaying topic name with wildcard subscriptions
 - Pre-defined topic IDs and short topic names
+- Forwarder encapsulation according to MQTT-SN Protocol Specification v1.2.
 
 
 Limitations
@@ -44,6 +45,8 @@ Publishing
       -r             Message should be retained.
       -t <topic>     MQTT topic name to publish to.
       -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.
+      --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
+      --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.
 
 
 Subscribing
@@ -60,14 +63,16 @@ Subscribing
       -p <port>      Network port to connect to. Defaults to 1883.
       -t <topic>     MQTT topic name to subscribe to.
       -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.
+      --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
+      --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.
       -v             Print messages verbosely, showing the topic name.
 
 
 Serial Port Bridge
 ------------------
 
-The Serial Port bridge can be used to relay packets from a remote device on the end of a 
-serial port and convert them into UDP packets, which are sent and received from a broker 
+The Serial Port bridge can be used to relay packets from a remote device on the end of a
+serial port and convert them into UDP packets, which are sent and received from a broker
 or MQTT-SN gateway.
 
     Usage: mqtt-sn-serial-bridge [opts] <device>
@@ -77,6 +82,7 @@ or MQTT-SN gateway.
       -dd            Enable extended debugging - display packets in hex.
       -h <host>      MQTT-SN host to connect to. Defaults to '127.0.0.1'.
       -p <port>      Network port to connect to. Defaults to 1883.
+      --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
 
 
 License

--- a/mqtt-sn-serial-bridge.c
+++ b/mqtt-sn-serial-bridge.c
@@ -300,7 +300,7 @@ int main(int argc, char* argv[])
             void *packet = serial_read_packet(fd);
             if (packet) {
 				if ( frwdencap ) {
-					mqtt_sn_send_frwdencap_packet(sock , packet , null, 0) ;
+					mqtt_sn_send_frwdencap_packet(sock , packet , NULL, 0) ;
 				} else {
 					mqtt_sn_send_packet(sock, packet);
 				}

--- a/mqtt-sn-serial-bridge.c
+++ b/mqtt-sn-serial-bridge.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -48,6 +49,7 @@ const char *mqtt_sn_port = "1883";
 const char *serial_device = NULL;
 speed_t serial_baud = B9600;
 uint8_t debug = 0;
+uint8_t frwdencap = FALSE ;
 
 uint8_t keep_running = TRUE;
 
@@ -56,42 +58,61 @@ static void usage()
 {
     fprintf(stderr, "Usage: mqtt-sn-serial-bridge [opts] <device>\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "  -b <baud>      Set the baud rate. Defaults to %d.\n", (int)serial_baud);
-    fprintf(stderr, "  -d             Enable debug messages.\n");
-    fprintf(stderr, "  -dd            Enable extended debugging - display packets in hex.\n");
-    fprintf(stderr, "  -h <host>      MQTT-SN host to connect to. Defaults to '%s'.\n", mqtt_sn_host);
-    fprintf(stderr, "  -p <port>      Network port to connect to. Defaults to %s.\n", mqtt_sn_port);
+    fprintf(stderr, "  -b <baud>             Set the baud rate. Defaults to %d.\n", (int)serial_baud);
+    fprintf(stderr, "  -d                    Enable debug messages.\n");
+    fprintf(stderr, "  -dd                   Enable extended debugging - display packets in hex.\n");
+    fprintf(stderr, "  -h <host>             MQTT-SN host to connect to. Defaults to '%s'.\n", mqtt_sn_host);
+    fprintf(stderr, "  -p <port>             Network port to connect to. Defaults to %s.\n", mqtt_sn_port);
+    fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n" );	
     exit(-1);
 }
 
 static void parse_opts(int argc, char** argv)
 {
-    int ch;
+
+	static struct option long_options[] =
+	{
+		{"fe" ,    no_argument ,       0 , 'f' } ,
+		{0, 0, 0, 0}
+	} ;
+
+	int ch;
+	/* getopt_long stores the option index here. */
+	int option_index = 0;
 
     // Parse the options/switches
-    while ((ch = getopt(argc, argv, "b:dh:p:?")) != -1)
-        switch (ch) {
-        case 'b':
-            serial_baud = atoi(optarg);
-        break;
+	while ((ch = getopt_long (argc , argv , "b:dh:p:?" , long_options , &option_index )) != -1 ) 
+	{
 
-        case 'd':
-            debug++;
-        break;
+		switch (ch) 
+		{
+			case 'b' :
+				serial_baud = atoi(optarg);
+				break;
 
-        case 'h':
-            mqtt_sn_host = optarg;
-        break;
+	        case 'd' :
+	        	debug ++ ;
+	        	break ;
 
-        case 'p':
-            mqtt_sn_port = optarg;
-        break;
+	        case 'h' :
+	        	mqtt_sn_host = optarg;
+	        	break;
 
-        case '?':
-        default:
-            usage();
-        break;
-    }
+			case 'p' :
+	        	mqtt_sn_port = optarg;
+	        	break;
+
+			case 'f':
+            	mqtt_sn_enable_frwdencap() ;
+            	frwdencap = TRUE ;
+        	break;
+
+	        case '?' :
+	        default:
+	        	usage() ;
+	        break ;
+		} // switch
+	} // while
 
     // Final argument is the serial port device path
     if (argc-optind < 1) {
@@ -107,6 +128,8 @@ static int serial_open(const char* device_path)
 {
     struct termios tios;
     int fd;
+
+    mqtt_sn_disable_frwdencap() ;
 
     if (debug) {
         fprintf(stderr, "Opening %s\n", device_path);
@@ -165,19 +188,22 @@ static void* serial_read_packet(int fd)
     // First get the length of the packet
     int bytes_read = read(fd, buf, 1);
     if (bytes_read != 1) {
-        fprintf(stderr, "Error reading packet length from serial port: %d, %d\n", bytes_read, errno);
+    	__CUR_TIME__
+        fprintf(stderr, "%s Error reading packet length from serial port: %d, %d\n", tm_buffer , bytes_read, errno);
         return NULL;
     }
 
     if (buf[0] == 0x00) {
-        fprintf(stderr, "Error: packets of length 0 are invalid.\n");
+    	__CUR_TIME__
+        fprintf(stderr, "%s Error: packets of length 0 are invalid.\n" , tm_buffer ) ;
         return NULL;
     }
 
     // Read in the rest of the packet
     bytes_read = read(fd, &buf[1], buf[0]-1);
     if (bytes_read <= 0) {
-        fprintf(stderr, "Error reading rest of packet from serial port: %d, %d\n", bytes_read, errno);
+    	__CUR_TIME__
+        fprintf(stderr, "%s Error reading rest of packet from serial port: %d, %d\n", tm_buffer , bytes_read, errno);
         return NULL;
     } else {
         bytes_read += 1;
@@ -192,7 +218,8 @@ static void* serial_read_packet(int fd)
 
     if (debug) {
         const char* type = mqtt_sn_type_string(buf[1]);
-        fprintf(stderr, "Serial -> UDP (bytes_read=%d, type=%s)\n", bytes_read, type);
+        __CUR_TIME__
+        fprintf(stderr, "%s Serial -> UDP (bytes_read=%d, type=%s)\n", tm_buffer , bytes_read, type);
         if (debug > 1) {
             int i;
             fprintf(stderr, "  ");
@@ -212,19 +239,20 @@ void serial_write_packet(int fd, const void* packet)
 
     sent = write(fd, packet, len);
     if (sent != len) {
-        fprintf(stderr, "Warning: only sent %d of %d bytes\n", (int)sent, (int)len);
+    	__CUR_TIME__
+        fprintf(stderr, "%s Warning: only sent %d of %d bytes\n", tm_buffer , (int)sent, (int)len);
     }
 }
 
 static void termination_handler (int signum)
 {
     switch(signum) {
-        case SIGHUP:  fprintf(stderr, "Got hangup signal."); break;
-        case SIGTERM: fprintf(stderr, "Got termination signal."); break;
-        case SIGINT:  fprintf(stderr, "Got interupt signal."); break;
+        case SIGHUP:  fprintf(stderr, "Got hangup signal.\n"); break;
+        case SIGTERM: fprintf(stderr, "Got termination signal.\n"); break;
+        case SIGINT:  fprintf(stderr, "Got interrupt signal.\n"); break;
     }
 
-    // Signal the main thead to stop
+    // Signal the main thread to stop
     keep_running = FALSE;
 }
 
@@ -236,6 +264,9 @@ int main(int argc, char* argv[])
 
     // Parse the command-line options
     parse_opts(argc, argv);
+	if (debug){
+		fprintf(stderr, "Debug level:    %i\n", debug ) ;
+	}
 
     mqtt_sn_set_debug(debug);
 
@@ -253,9 +284,9 @@ int main(int argc, char* argv[])
     while (keep_running) {
         fd_set fdset;
 
-        FD_ZERO(&fdset);
-        FD_SET(fd, &fdset);
-        FD_SET(sock, &fdset);
+        FD_ZERO(&fdset);			// Clear the socket set
+        FD_SET(fd, &fdset);			// Add serial into fdset
+        FD_SET(sock, &fdset);		// Add socket into fdset
 
         if (select(FD_SETSIZE, &fdset, NULL, NULL, NULL) < 0) {
             if (errno != EINTR) {
@@ -264,10 +295,15 @@ int main(int argc, char* argv[])
             break;
         }
 
+        // Read serial line
         if (FD_ISSET(fd, &fdset)) {
             void *packet = serial_read_packet(fd);
             if (packet) {
-                mqtt_sn_send_packet(sock, packet);
+				if ( frwdencap ) {
+					mqtt_sn_send_frwdencap_packet(sock , packet , null, 0) ;
+				} else {
+					mqtt_sn_send_packet(sock, packet);
+				}
             }
         }
 

--- a/mqtt-sn-sub.c
+++ b/mqtt-sn-sub.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -42,7 +43,7 @@ const char *mqtt_sn_port = "1883";
 uint16_t topic_id = 0;
 uint16_t keep_alive = 10;
 uint8_t retain = FALSE;
-uint8_t debug = FALSE;
+uint8_t debug = 0;
 uint8_t single_message = FALSE;
 uint8_t clean_session = TRUE;
 uint8_t verbose = FALSE;
@@ -62,16 +63,28 @@ static void usage()
     fprintf(stderr, "  -p <port>      Network port to connect to. Defaults to %s.\n", mqtt_sn_port);
     fprintf(stderr, "  -t <topic>     MQTT topic name to subscribe to.\n");
     fprintf(stderr, "  -T <topicid>   Pre-defined MQTT-SN topic ID to subscrube to.\n");
+    fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n" );
+    fprintf(stderr, "  --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.\n" );
     fprintf(stderr, "  -v             Print messages verbosely, showing the topic name.\n");
     exit(-1);
 }
 
 static void parse_opts(int argc, char** argv)
 {
+
+	static struct option long_options[] =
+	{
+		{"fe" ,    no_argument ,       0 , 'f' } ,
+		{"wlnid" , optional_argument , 0 , 'w' } ,
+		{0, 0, 0, 0}
+	} ;
+
     int ch;
+	/* getopt_long stores the option index here. */
+	int option_index = 0;
 
     // Parse the options/switches
-    while ((ch = getopt(argc, argv, "1cdh:i:k:p:t:T:v?")) != -1)
+    while ((ch = getopt_long (argc , argv , "1cdh:i:k:p:t:T:v?" , long_options , &option_index )) != -1)
         switch (ch) {
         case '1':
             single_message = TRUE;
@@ -82,7 +95,7 @@ static void parse_opts(int argc, char** argv)
         break;
 
         case 'd':
-            debug = TRUE;
+            debug ++ ;
         break;
 
         case 'h':
@@ -109,6 +122,14 @@ static void parse_opts(int argc, char** argv)
             topic_id = atoi(optarg);
         break;
 
+        case 'f':
+            mqtt_sn_enable_frwdencap() ;
+        break;
+
+        case 'w' :
+        	mqtt_sn_set_frwdencap_parameters( (uint8_t*)optarg , strlen(optarg) ) ;
+		break;
+
         case 'v':
             verbose = TRUE;
         break;
@@ -134,9 +155,9 @@ static void parse_opts(int argc, char** argv)
 static void termination_handler (int signum)
 {
     switch(signum) {
-        case SIGHUP:  fprintf(stderr, "Got hangup signal."); break;
-        case SIGTERM: fprintf(stderr, "Got termination signal."); break;
-        case SIGINT:  fprintf(stderr, "Got interupt signal."); break;
+        case SIGHUP:  fprintf(stderr, "Got hangup signal.\n"); break;
+        case SIGTERM: fprintf(stderr, "Got termination signal.\n"); break;
+        case SIGINT:  fprintf(stderr, "Got interupt signal.\n"); break;
     }
 
     // Signal the main thead to stop
@@ -146,6 +167,8 @@ static void termination_handler (int signum)
 int main(int argc, char* argv[])
 {
     int sock, timeout;
+
+    mqtt_sn_disable_frwdencap() ;
 
     // Parse the command-line options
     parse_opts(argc, argv);
@@ -167,7 +190,8 @@ int main(int argc, char* argv[])
 
     // Create a UDP socket
     sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port);
-    if (sock) {
+    if (sock)
+    {
         // Connect to gateway
         mqtt_sn_send_connect(sock, client_id, keep_alive);
         mqtt_sn_receive_connack(sock);
@@ -186,9 +210,11 @@ int main(int argc, char* argv[])
         }
 
         // Keep processing packets until process is terminated
-        while(keep_running) {
+        while(keep_running)
+        {
             publish_packet_t *packet = mqtt_sn_loop(sock, timeout);
-            if (packet) {
+            if (packet)
+            {
                 if (verbose) {
                     int topic_type = packet->flags & 0x3;
                     int topic_id = ntohs(packet->topic_id);

--- a/mqtt-sn.h
+++ b/mqtt-sn.h
@@ -36,6 +36,7 @@
 
 #define MQTT_SN_MAX_PACKET_LENGTH  (255)
 #define MQTT_SN_MAX_TOPIC_LENGTH   (MQTT_SN_MAX_PACKET_LENGTH-6)
+#define MQTT_SN_MAX_WIRELESS_NODE_ID_LENGTH  (252)
 
 #define MQTT_SN_TYPE_ADVERTISE     (0x00)
 #define MQTT_SN_TYPE_SEARCHGW      (0x01)
@@ -64,6 +65,7 @@
 #define MQTT_SN_TYPE_WILLTOPICRESP (0x1B)
 #define MQTT_SN_TYPE_WILLMSGUPD    (0x1C)
 #define MQTT_SN_TYPE_WILLMSGRESP   (0x1D)
+#define MQTT_SN_TYPE_FRWDENCAP     (0xFE)
 
 #define MQTT_SN_TOPIC_TYPE_NORMAL     (0x00)
 #define MQTT_SN_TOPIC_TYPE_PREDEFINED (0x01)
@@ -147,6 +149,14 @@ typedef struct {
   uint16_t duration;
 } disconnect_packet_t;
 
+typedef struct __attribute__((packed)) {
+  uint8_t length;
+  uint8_t type;
+  uint16_t ctrl;
+  uint8_t wireless_node_id[MQTT_SN_MAX_WIRELESS_NODE_ID_LENGTH];
+  char data[MQTT_SN_MAX_PACKET_LENGTH];
+} frwdencap_packet_t;
+
 typedef struct topic_map {
   uint16_t topic_id;
   char topic_name[MQTT_SN_MAX_TOPIC_LENGTH];
@@ -180,8 +190,20 @@ const char* mqtt_sn_type_string(uint8_t type);
 const char* mqtt_sn_return_code_string(uint8_t return_code);
 
 uint8_t mqtt_sn_validate_packet(const void *packet, size_t length);
-void mqtt_sn_send_packet(int sock, const void* data);
+void mqtt_sn_send_packet(int sock, void* data);
+void mqtt_sn_send_frwdencap_packet(int sock, void* data, const uint8_t *wireless_node_id , uint8_t wireless_node_id_len );
 void* mqtt_sn_receive_packet(int sock);
+void* mqtt_sn_receive_frwdencap_packet(int sock, uint8_t **wireless_node_id , uint8_t *wireless_node_id_len);
 
+// Functions to turn on and off forwarder encapsulation according to MQTT-SN Protocol Specification v1.2,
+// chapter 5.5 Forwarder Encapsulation.
+uint8_t mqtt_sn_enable_frwdencap();
+uint8_t mqtt_sn_disable_frwdencap();
+// Set wireless node ID and wireless node ID length
+void mqtt_sn_set_frwdencap_parameters( const uint8_t *wlnid, uint8_t wlnid_len ) ;
+// Wrap mqtt-sn packet into a forwarder encapsulation packet
+frwdencap_packet_t* mqtt_sn_create_frwdencap_packet( const uint8_t *data , size_t *len , const uint8_t *wireless_node_id , uint8_t wireless_node_id_len ) ;
+// Print content of a buffer in hexadecimal format into a stream. It is used to log wireless node ID.
+void fprint_wlnid( FILE * stream , const uint8_t *wireless_node_id , uint8_t wireless_node_id_len ) ;
 
 #endif

--- a/mqtt-sn.h
+++ b/mqtt-sn.h
@@ -153,6 +153,10 @@ typedef struct topic_map {
   struct topic_map *next;
 } topic_map_t;
 
+// Logging stuff
+time_t rawtime ;
+char tm_buffer [40];
+#define __CUR_TIME__ time( &rawtime) ; strftime (tm_buffer , 40 ,"%T", localtime(&rawtime) ) ;
 
 // Library functions
 int mqtt_sn_create_socket(const char* host, const char* port);


### PR DESCRIPTION
1. Added support of Forwarder Encapsulation. Mqtt-SN packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5.

2. All log messages to stderr prefixed with current time, e.g:
       17:21:10 mqtt-sn-tools-8164 sending CONNECT packet...
       17:21:10 Waiting for a packet...
       17:21:10 Received  3 bytes. Type=CONNACK on Socket: 3
       17:21:10 CONNACK return code: 0x00

3. Added ignore of exe files into .gitignore.