### PR TITLE
Forwarder Encapsulation Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supported Features
 - Manual and automatic client ID generation
 - Displaying topic name with wildcard subscriptions
 - Pre-defined topic IDs and short topic names
+- Forwarder encapsulation according to MQTT-SN Protocol Specification v1.2.
 
 
 Limitations
@@ -34,7 +35,7 @@ Publishing
 
     Usage: mqtt-sn-pub [opts] -t <topic> -m <message>
 
-      -d             Enable debug messages.
+      -d             Increase debug level by one. -d can occur multiple times.
       -h <host>      MQTT-SN host to connect to. Defaults to '127.0.0.1'.
       -i <clientid>  ID to use for this client. Defaults to 'mqtt-sn-tools-' with process id.
       -m <message>   Message payload to send.
@@ -44,6 +45,8 @@ Publishing
       -r             Message should be retained.
       -t <topic>     MQTT topic name to publish to.
       -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.
+      --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
+      --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.
 
 
 Subscribing
@@ -53,30 +56,33 @@ Subscribing
 
       -1             exit after receiving a single message.
       -c             disable 'clean session' (store subscription and pending messages when client disconnects).
-      -d             Enable debug messages.
+      -d             Increase debug level by one. -d can occur multiple times.
       -h <host>      MQTT-SN host to connect to. Defaults to '127.0.0.1'.
       -i <clientid>  ID to use for this client. Defaults to 'mqtt-sn-tools-' with process id.
       -k <keepalive> keep alive in seconds for this client. Defaults to 10.
       -p <port>      Network port to connect to. Defaults to 1883.
       -t <topic>     MQTT topic name to subscribe to.
       -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.
+      --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
+      --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.
       -v             Print messages verbosely, showing the topic name.
 
 
 Serial Port Bridge
 ------------------
 
-The Serial Port bridge can be used to relay packets from a remote device on the end of a 
-serial port and convert them into UDP packets, which are sent and received from a broker 
+The Serial Port bridge can be used to relay packets from a remote device on the end of a
+serial port and convert them into UDP packets, which are sent and received from a broker
 or MQTT-SN gateway.
 
     Usage: mqtt-sn-serial-bridge [opts] <device>
 
       -b <baud>      Set the baud rate. Defaults to 9600.
-      -d             Enable debug messages.
+      -d             Increase debug level by one. -d can occur multiple times.
       -dd            Enable extended debugging - display packets in hex.
       -h <host>      MQTT-SN host to connect to. Defaults to '127.0.0.1'.
       -p <port>      Network port to connect to. Defaults to 1883.
+      --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
 
 
 License

--- a/mqtt-sn-pub.c
+++ b/mqtt-sn-pub.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -45,14 +46,14 @@ uint16_t topic_id = 0;
 uint8_t topic_id_type = MQTT_SN_TOPIC_TYPE_NORMAL;
 int8_t qos = 0;
 uint8_t retain = FALSE;
-uint8_t debug = FALSE;
+uint8_t debug = 0;
 
 
 static void usage()
 {
     fprintf(stderr, "Usage: mqtt-sn-pub [opts] -t <topic> -m <message>\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "  -d             Enable debug messages.\n");
+    fprintf(stderr, "  -d             Increase debug level by one. -d can occur multiple times.\n");
     fprintf(stderr, "  -h <host>      MQTT-SN host to connect to. Defaults to '%s'.\n", mqtt_sn_host);
     fprintf(stderr, "  -i <clientid>  ID to use for this client. Defaults to 'mqtt-sn-tools-' with process id.\n");
     fprintf(stderr, "  -m <message>   Message payload to send.\n");
@@ -62,18 +63,31 @@ static void usage()
     fprintf(stderr, "  -r             Message should be retained.\n");
     fprintf(stderr, "  -t <topic>     MQTT topic name to publish to.\n");
     fprintf(stderr, "  -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.\n");
+    fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n" );
+    fprintf(stderr, "  --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.\n" );
     exit(-1);
 }
 
 static void parse_opts(int argc, char** argv)
 {
+
+    static struct option long_options[] =
+    {
+        {"fe" ,    no_argument ,       0 , 'f' } ,
+        {"wlnid" , required_argument , 0 , 'w' } ,
+        {0, 0, 0, 0}
+    } ;
+
     int ch;
+    /* getopt_long stores the option index here. */
+    int option_index = 0;
 
     // Parse the options/switches
-    while ((ch = getopt(argc, argv, "dh:i:m:np:q:rt:T:?")) != -1)
+    while ((ch = getopt_long (argc , argv , "dh:i:m:np:q:rt:T:?" , long_options , &option_index )) != -1 )
+    {
         switch (ch) {
         case 'd':
-            debug = TRUE;
+            debug++ ;
             break;
 
         case 'h':
@@ -112,11 +126,20 @@ static void parse_opts(int argc, char** argv)
             topic_id = atoi(optarg);
             break;
 
+        case 'f':
+            mqtt_sn_enable_frwdencap() ;
+            break;
+
+        case 'w' :
+            mqtt_sn_set_frwdencap_parameters( (uint8_t*)optarg , strlen(optarg) ) ;
+            break;
+
         case '?':
         default:
             usage();
             break;
-        }
+        } // switch
+    } // while
 
     // Missing Parameter?
     if (!(topic_name || topic_id) || !message_data) {
@@ -144,6 +167,8 @@ static void parse_opts(int argc, char** argv)
 int main(int argc, char* argv[])
 {
     int sock;
+
+    mqtt_sn_disable_frwdencap() ;
 
     // Parse the command-line options
     parse_opts(argc, argv);

--- a/mqtt-sn-serial-bridge.c
+++ b/mqtt-sn-serial-bridge.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -48,6 +49,7 @@ const char *mqtt_sn_port = "1883";
 const char *serial_device = NULL;
 speed_t serial_baud = B9600;
 uint8_t debug = 0;
+uint8_t frwdencap = FALSE ;
 
 uint8_t keep_running = TRUE;
 
@@ -57,19 +59,30 @@ static void usage()
     fprintf(stderr, "Usage: mqtt-sn-serial-bridge [opts] <device>\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "  -b <baud>      Set the baud rate. Defaults to %d.\n", (int)serial_baud);
-    fprintf(stderr, "  -d             Enable debug messages.\n");
+    fprintf(stderr, "  -d             Increase debug level by one. -d can occur multiple times.\n");
     fprintf(stderr, "  -dd            Enable extended debugging - display packets in hex.\n");
     fprintf(stderr, "  -h <host>      MQTT-SN host to connect to. Defaults to '%s'.\n", mqtt_sn_host);
     fprintf(stderr, "  -p <port>      Network port to connect to. Defaults to %s.\n", mqtt_sn_port);
+    fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n" );
     exit(-1);
 }
 
 static void parse_opts(int argc, char** argv)
 {
+
+    static struct option long_options[] =
+    {
+        {"fe" ,    no_argument ,       0 , 'f' } ,
+        {0, 0, 0, 0}
+    } ;
+
     int ch;
+    /* getopt_long stores the option index here. */
+    int option_index = 0;
 
     // Parse the options/switches
-    while ((ch = getopt(argc, argv, "b:dh:p:?")) != -1)
+    while ((ch = getopt_long (argc , argv , "b:dh:p:?" , long_options , &option_index )) != -1 )
+    {
         switch (ch) {
         case 'b':
             serial_baud = atoi(optarg);
@@ -87,11 +100,16 @@ static void parse_opts(int argc, char** argv)
             mqtt_sn_port = optarg;
             break;
 
+        case 'f':
+            mqtt_sn_enable_frwdencap();
+            frwdencap = TRUE;
+            break;
         case '?':
         default:
             usage();
             break;
-        }
+        } // switch
+    } // while
 
     // Final argument is the serial port device path
     if (argc-optind < 1) {
@@ -108,6 +126,8 @@ static int serial_open(const char* device_path)
     struct termios tios;
     int fd;
 
+    mqtt_sn_disable_frwdencap() ;
+	
     log_debug("Opening %s", device_path);
 
     fd = open(device_path, O_RDWR | O_NOCTTY | O_NDELAY );
@@ -260,9 +280,9 @@ int main(int argc, char* argv[])
     while (keep_running) {
         fd_set fdset;
 
-        FD_ZERO(&fdset);
-        FD_SET(fd, &fdset);
-        FD_SET(sock, &fdset);
+        FD_ZERO(&fdset);                // Clear the socket set
+        FD_SET(fd, &fdset);             // Add serial into fdset
+        FD_SET(sock, &fdset);           // Add socket into fdset
 
         if (select(FD_SETSIZE, &fdset, NULL, NULL, NULL) < 0) {
             if (errno != EINTR) {
@@ -271,10 +291,15 @@ int main(int argc, char* argv[])
             break;
         }
 
+        // Read serial line
         if (FD_ISSET(fd, &fdset)) {
             void *packet = serial_read_packet(fd);
             if (packet) {
-                mqtt_sn_send_packet(sock, packet);
+                if ( frwdencap ) {
+                    mqtt_sn_send_frwdencap_packet(sock , packet , NULL, 0) ;
+                } else {
+                    mqtt_sn_send_packet(sock, packet);
+                }
             }
         }
 

--- a/mqtt-sn-sub.c
+++ b/mqtt-sn-sub.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -42,7 +43,7 @@ const char *mqtt_sn_port = "1883";
 uint16_t topic_id = 0;
 uint16_t keep_alive = 10;
 uint8_t retain = FALSE;
-uint8_t debug = FALSE;
+uint8_t debug = 0;
 uint8_t single_message = FALSE;
 uint8_t clean_session = TRUE;
 uint8_t verbose = FALSE;
@@ -55,23 +56,35 @@ static void usage()
     fprintf(stderr, "\n");
     fprintf(stderr, "  -1             exit after receiving a single message.\n");
     fprintf(stderr, "  -c             disable 'clean session' (store subscription and pending messages when client disconnects).\n");
-    fprintf(stderr, "  -d             Enable debug messages.\n");
+    fprintf(stderr, "  -d             Increase debug level by one. -d can occur multiple times.\n");
     fprintf(stderr, "  -h <host>      MQTT-SN host to connect to. Defaults to '%s'.\n", mqtt_sn_host);
     fprintf(stderr, "  -i <clientid>  ID to use for this client. Defaults to 'mqtt-sn-tools-' with process id.\n");
     fprintf(stderr, "  -k <keepalive> keep alive in seconds for this client. Defaults to %d.\n", keep_alive);
     fprintf(stderr, "  -p <port>      Network port to connect to. Defaults to %s.\n", mqtt_sn_port);
     fprintf(stderr, "  -t <topic>     MQTT topic name to subscribe to.\n");
     fprintf(stderr, "  -T <topicid>   Pre-defined MQTT-SN topic ID to subscrube to.\n");
+    fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n" );
+    fprintf(stderr, "  --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.\n" );
     fprintf(stderr, "  -v             Print messages verbosely, showing the topic name.\n");
     exit(-1);
 }
 
 static void parse_opts(int argc, char** argv)
 {
+
+    static struct option long_options[] =
+    {
+        {"fe" ,    no_argument ,       0 , 'f' } ,
+        {"wlnid" , required_argument , 0 , 'w' } ,
+        {0, 0, 0, 0}
+    } ;
+
     int ch;
+    /* getopt_long stores the option index here. */
+    int option_index = 0;
 
     // Parse the options/switches
-    while ((ch = getopt(argc, argv, "1cdh:i:k:p:t:T:v?")) != -1)
+    while ((ch = getopt_long (argc , argv , "1cdh:i:k:p:t:T:v?" , long_options , &option_index )) != -1)
         switch (ch) {
         case '1':
             single_message = TRUE;
@@ -82,7 +95,7 @@ static void parse_opts(int argc, char** argv)
             break;
 
         case 'd':
-            debug = TRUE;
+            debug++ ;
             break;
 
         case 'h':
@@ -107,6 +120,14 @@ static void parse_opts(int argc, char** argv)
 
         case 'T':
             topic_id = atoi(optarg);
+            break;
+
+        case 'f':
+            mqtt_sn_enable_frwdencap() ;
+            break;
+
+        case 'w' :
+            mqtt_sn_set_frwdencap_parameters( (uint8_t*)optarg , strlen(optarg) ) ;
             break;
 
         case 'v':
@@ -145,13 +166,15 @@ static void termination_handler (int signum)
         break;
     }
 
-    // Signal the main thead to stop
+    // Signal the main thread to stop
     keep_running = FALSE;
 }
 
 int main(int argc, char* argv[])
 {
     int sock, timeout;
+
+    mqtt_sn_disable_frwdencap() ;
 
     // Parse the command-line options
     parse_opts(argc, argv);

--- a/mqtt-sn.c
+++ b/mqtt-sn.c
@@ -42,20 +42,23 @@
 #define AI_DEFAULT (AI_ADDRCONFIG|AI_V4MAPPED)
 #endif
 
-static uint8_t debug_enabled = FALSE;
+static uint8_t debug = 0;
 static uint16_t next_message_id = 1;
 static time_t last_transmit = 0;
 static time_t last_receive = 0;
 static time_t keep_alive = 0;
 static time_t log_time ;
 static char tm_buffer [40];
+static uint8_t forwarder_encapsulation = FALSE;
+const uint8_t *wireless_node_id = NULL ;
+uint8_t wireless_node_id_len  = 0;
 
 topic_map_t *topic_map = NULL;
 
 
 void mqtt_sn_set_debug(uint8_t value)
 {
-    debug_enabled = value;
+    debug = value;
 }
 
 int mqtt_sn_create_socket(const char* host, const char* port)
@@ -117,9 +120,26 @@ int mqtt_sn_create_socket(const char* host, const char* port)
     return fd;
 }
 
-void mqtt_sn_send_packet(int sock, const void* data)
+
+void mqtt_sn_send_packet(int sock, void* data)
 {
     size_t sent, len = ((uint8_t*)data)[0];
+    uint8_t origPacketType = ((uint8_t*)data)[1] ;
+
+    // If forwarder encapsulation enabled, wrap packet
+    if ( forwarder_encapsulation ) {
+        data = mqtt_sn_create_frwdencap_packet( data , &len , wireless_node_id , wireless_node_id_len) ;
+    }
+
+    if (debug > 1) {
+        if (forwarder_encapsulation) {
+            log_debug( "Sending  %2lu bytes. Type=%s with %s inside on Socket: %d." , (long unsigned int)len ,
+                    mqtt_sn_type_string(((uint8_t*)data)[1]) , mqtt_sn_type_string(origPacketType) , sock ) ;
+        } else {
+            log_debug( "Sending  %2lu bytes. Type=%s on Socket: %d." , (long unsigned int)len ,
+                    mqtt_sn_type_string(((uint8_t*)data)[1]) , sock ) ;
+        }
+    }
 
     sent = send(sock, data, len, 0);
     if (sent != len) {
@@ -128,7 +148,38 @@ void mqtt_sn_send_packet(int sock, const void* data)
 
     // Store the last time that we sent a packet
     last_transmit = time(NULL);
+
+    // If forwarder encapsulation enabled free encapsulation packet memory
+    if ( forwarder_encapsulation ) {
+        free(data)  ;
+    }
+
 }
+
+
+void mqtt_sn_send_frwdencap_packet(int sock, void* data, const uint8_t *wireless_node_id , uint8_t wireless_node_id_len )
+{
+    size_t sent, len = ((uint8_t*)data)[0];
+    uint8_t origPacketType = ((uint8_t*)data)[1] ;
+
+    data = mqtt_sn_create_frwdencap_packet( data , &len , wireless_node_id , wireless_node_id_len ) ;
+
+    if (debug > 1) {
+        log_debug( "Sending  %2lu bytes. Type=%s with %s inside on Socket: %d." , (long unsigned int)len ,
+                mqtt_sn_type_string(((uint8_t*)data)[1]) , mqtt_sn_type_string(origPacketType) , sock ) ;
+    }
+
+    sent = send(sock, data, len, 0);
+    if (sent != len) {
+        log_debug( "Warning: only sent %d of %d bytes.", (int)sent , (int)len);
+    }
+
+    // Store the last time that we sent a packet
+    last_transmit = time(NULL);
+
+    free(data)  ;
+}
+
 
 uint8_t mqtt_sn_validate_packet(const void *packet, size_t length)
 {
@@ -144,8 +195,18 @@ uint8_t mqtt_sn_validate_packet(const void *packet, size_t length)
         return FALSE;
     }
 
-    if (buf[0] != length) {
-        log_err("Read %d bytes but packet length is %d bytes.", (int)length, (int)buf[0]);
+    // When forwarder encapsulation is enabled each packet must be FRWDENCAP type
+    if ( forwarder_encapsulation && buf[1] != MQTT_SN_TYPE_FRWDENCAP) {
+        log_err( "Expecting FRWDENCAP packet and got Type=%s." , mqtt_sn_type_string(buf[1]));
+        return FALSE;
+    }
+
+    // If packet is forwarder encapsulation expected packet length is sum of forwarder encapsulation
+    // header and length of encapsulated packet.
+    if (    (buf[1] == MQTT_SN_TYPE_FRWDENCAP && buf[0] + buf[buf[0]] != length) ||
+            (buf[1] != MQTT_SN_TYPE_FRWDENCAP && buf[0] != length) ) {
+        log_err( "Read %d bytes but packet length is %d bytes.", (int)length ,
+                buf[1] != MQTT_SN_TYPE_FRWDENCAP ? (int)buf[0] : (int)(buf[0] + buf[buf[0]]) );
         return FALSE;
     }
 
@@ -154,13 +215,23 @@ uint8_t mqtt_sn_validate_packet(const void *packet, size_t length)
 
 void* mqtt_sn_receive_packet(int sock)
 {
-    static uint8_t buffer[MQTT_SN_MAX_PACKET_LENGTH+1];
+    uint8_t *wireless_node_id  = NULL ;
+    uint8_t wireless_node_id_len = 0 ;
+
+    return mqtt_sn_receive_frwdencap_packet(sock, &wireless_node_id , &wireless_node_id_len) ;
+}
+void* mqtt_sn_receive_frwdencap_packet(int sock, uint8_t **wireless_node_id , uint8_t *wireless_node_id_len)
+{
+    *wireless_node_id = NULL ;
+    *wireless_node_id_len = 0 ;
+    static uint8_t buffer[MQTT_SN_MAX_PACKET_LENGTH + MQTT_SN_MAX_WIRELESS_NODE_ID_LENGTH + 3  + 1];
+    uint8_t *packet = buffer ;
     int bytes_read;
 
     log_debug("waiting for packet...");
 
     // Read in the packet
-    bytes_read = recv(sock, buffer, MQTT_SN_MAX_PACKET_LENGTH, 0);
+    bytes_read = recv(sock, buffer, sizeof(buffer), 0);
     if (bytes_read < 0) {
         if (errno == EAGAIN) {
             log_debug("Timed out waiting for packet.");
@@ -171,7 +242,14 @@ void* mqtt_sn_receive_packet(int sock)
         }
     }
 
-    log_debug("Received %d bytes. Type=%s.", (int)bytes_read, mqtt_sn_type_string(buffer[1]));
+
+    if (packet[1] == MQTT_SN_TYPE_FRWDENCAP) {
+        log_debug( "Received %2d bytes. Type=%s with %s inside on Socket: %d" , (int)bytes_read ,
+                mqtt_sn_type_string(buffer[1]) , mqtt_sn_type_string(packet[packet[0] + 1]) , sock) ;
+    } else {
+        log_debug( "Received %2d bytes. Type=%s on Socket: %d" , (int)bytes_read ,
+                mqtt_sn_type_string(buffer[1]) , sock ) ;
+    }
 
     if (mqtt_sn_validate_packet(buffer, bytes_read) == FALSE) {
         return NULL;
@@ -180,10 +258,18 @@ void* mqtt_sn_receive_packet(int sock)
     // NULL-terminate the packet
     buffer[bytes_read] = '\0';
 
+    if (packet[1] == MQTT_SN_TYPE_FRWDENCAP)
+    {
+        *wireless_node_id = &packet[3] ;
+        *wireless_node_id_len = packet[0] - 3 ;
+        // Shift packet by the actual length of FRWDENCAP header
+        packet += packet[0] ;
+    }
+
     // Store the last time that we received a packet
     last_receive = time(NULL);
 
-    return buffer;
+    return packet;
 }
 
 void mqtt_sn_send_connect(int sock, const char* client_id, uint16_t keepalive)
@@ -654,6 +740,7 @@ const char* mqtt_sn_type_string(uint8_t type)
         case MQTT_SN_TYPE_WILLTOPICRESP: return "WILLTOPICRESP";
         case MQTT_SN_TYPE_WILLMSGUPD:    return "WILLMSGUPD";
         case MQTT_SN_TYPE_WILLMSGRESP:   return "WILLMSGRESP";
+        case MQTT_SN_TYPE_FRWDENCAP:     return "FRWDENCAP";
         default:                         return "UNKNOWN";
     }
 }
@@ -683,6 +770,80 @@ void mqtt_sn_cleanup()
     topic_map = NULL ;
 }
 
+
+uint8_t mqtt_sn_enable_frwdencap() {
+    return forwarder_encapsulation = TRUE ;
+}
+
+
+uint8_t mqtt_sn_disable_frwdencap() {
+    return forwarder_encapsulation = FALSE ;
+}
+
+
+void mqtt_sn_set_frwdencap_parameters( const uint8_t *wlnid, uint8_t wlnid_len ){
+    wireless_node_id = wlnid ;
+    wireless_node_id_len = wlnid_len ;
+}
+
+
+frwdencap_packet_t* mqtt_sn_create_frwdencap_packet( const uint8_t *data , size_t *len , const uint8_t *wireless_node_id , uint8_t wireless_node_id_len)
+{
+    frwdencap_packet_t* packet = NULL ;
+
+    // Check that it isn't too long
+    if (wireless_node_id_len > MQTT_SN_MAX_WIRELESS_NODE_ID_LENGTH) {
+        log_err( "Wireless node id is longer than %d" , MQTT_SN_MAX_WIRELESS_NODE_ID_LENGTH );
+        exit(EXIT_FAILURE);
+    }
+
+    // Allocates a block of memory for an array of num elements, each of them size bytes long,
+    // and initializes all its bits to zero.
+    packet = malloc( sizeof(frwdencap_packet_t) ) ;
+    packet->type = MQTT_SN_TYPE_FRWDENCAP ;
+    packet->ctrl = 0 ;
+
+    // Generate a Wireless Node ID if none given
+    if (wireless_node_id == NULL || wireless_node_id_len == 0) {
+        // A null character is automatically appended after the content written.
+        snprintf((char*)packet->wireless_node_id, sizeof(packet->wireless_node_id)-1, "%X", getpid());
+        wireless_node_id_len = strlen( (char*)packet->wireless_node_id ) ;
+    } else {
+        memcpy(packet->wireless_node_id, wireless_node_id, wireless_node_id_len);
+    }
+
+    packet->length = wireless_node_id_len + 3;
+
+    // Copy mqtt-sn packet into forwarder encapsulation packet
+    memcpy( &(packet->wireless_node_id[wireless_node_id_len]) , data , ((uint8_t*)data)[0] ) ;
+
+    // Set new packet length to send
+    *len = packet->length + ((uint8_t*)data)[0] ;
+
+    if (debug > 2) {
+        char wlnd[65] ;
+        char* buf_ptr = wlnd;
+        int i ;
+        for (i = 0; i < wireless_node_id_len; i++)
+        {
+            buf_ptr += sprintf(buf_ptr, "%02X", packet->wireless_node_id[i]);
+        }
+        *(++buf_ptr) = '\0';
+
+        log_debug("Node id: 0x%s, N. id len: %d, Wrapped packet len: %d, Total len: %lu" ,
+                wlnd , wireless_node_id_len , ((uint8_t*)data)[0] , (long unsigned int)*len ) ;
+    }
+
+    return packet ;
+}
+
+
+void fprint_wlnid( FILE * stream , const uint8_t *wireless_node_id , uint8_t wireless_node_id_len ){
+    int i ;
+    for (i = 0 ; i < wireless_node_id_len ; i++)
+        fprintf( stream , "%02X", wireless_node_id[i]);
+}
+
 void log_msg(const char* level, const char* format, va_list arglist )
 {
     time(&log_time) ;
@@ -696,7 +857,7 @@ void log_msg(const char* level, const char* format, va_list arglist )
 
 void log_debug(const char * format, ...)
 {
-    if (debug_enabled) {
+    if (debug) {
         va_list arglist;
         va_start(arglist, format);
         log_msg("DEBUG ", format, arglist);


### PR DESCRIPTION
1. Mqtt-SN packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
2. Added log levels. Each '-d' command line option increases log level by 1. Highest implemented level is 3.
