### PR TITLE
Reply with PUBACK when receiving a QoS1 PUBLISH

### DIFF
--- a/mqtt-sn.c
+++ b/mqtt-sn.c
@@ -730,8 +730,9 @@ void mqtt_sn_dump_packet(char* packet)
     printf("\n");
 }
 
-void mqtt_sn_print_publish_packet(publish_packet_t* packet)
+int mqtt_sn_print_publish_packet(publish_packet_t* packet)
 {
+	int rc = MQTT_SN_ACCEPTED;
     if (verbose) {
         int topic_type = packet->flags & 0x3;
         int topic_id = ntohs(packet->topic_id);
@@ -748,6 +749,9 @@ void mqtt_sn_print_publish_packet(publish_packet_t* packet)
             if (topic_name) {
                 printf("%s: %s\n", topic_name, packet->data);
             }
+            else{
+            	rc = MQTT_SN_REJECTED_INVALID;
+            }
             break;
         };
         case MQTT_SN_TOPIC_TYPE_PREDEFINED: {
@@ -763,6 +767,7 @@ void mqtt_sn_print_publish_packet(publish_packet_t* packet)
     } else {
         printf("%s\n", packet->data);
     }
+    return rc;
 }
 
 uint16_t mqtt_sn_receive_suback(int sock)
@@ -823,6 +828,7 @@ int mqtt_sn_select(int sock)
 void* mqtt_sn_wait_for(uint8_t type, int sock)
 {
     time_t started_waiting = time(NULL);
+    int rc;
 
     while(TRUE) {
         time_t now = time(NULL);
@@ -841,7 +847,11 @@ void* mqtt_sn_wait_for(uint8_t type, int sock)
             if (packet) {
                 switch(packet[1]) {
                     case MQTT_SN_TYPE_PUBLISH:
-                        mqtt_sn_print_publish_packet((publish_packet_t *)packet);
+                        rc = mqtt_sn_print_publish_packet((publish_packet_t *)packet);
+                        if(type == packet[1]){
+                        	return packet;
+                        }
+                        mqtt_sn_send_puback(sock,(publish_packet_t *)packet,rc);
                         break;
 
                     case MQTT_SN_TYPE_REGISTER:

--- a/mqtt-sn.h
+++ b/mqtt-sn.h
@@ -204,7 +204,7 @@ void mqtt_sn_receive_connack(int sock);
 uint16_t mqtt_sn_receive_regack(int sock);
 uint16_t mqtt_sn_receive_suback(int sock);
 void mqtt_sn_dump_packet(char* packet);
-void mqtt_sn_print_publish_packet(publish_packet_t* packet);
+int mqtt_sn_print_publish_packet(publish_packet_t* packet);
 int mqtt_sn_select(int sock);
 void* mqtt_sn_wait_for(uint8_t type, int sock);
 void mqtt_sn_register_topic(int topic_id, const char* topic_name);


### PR DESCRIPTION
Client automatically replies with PUBACK when receiving a PUBLISH of QoS 1 while waiting for another message