### PR TITLE
Make source port configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=cc
 PACKAGE=mqtt-sn-tools
-VERSION=0.0.8
+VERSION=0.0.7
 CFLAGS=-g -Wall -DVERSION=$(VERSION)
 LDFLAGS=
 INSTALL?=install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=cc
 PACKAGE=mqtt-sn-tools
-VERSION=0.0.7
+VERSION=0.0.8
 CFLAGS=-g -Wall -DVERSION=$(VERSION)
 LDFLAGS=
 INSTALL?=install

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Publishing
       -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.
       --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
       --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.
+      --cport <port> Source port for outgoing packets. Uses port in ephemeral range if not specified or set to 0.
 
 
 Subscribing
@@ -81,6 +82,7 @@ Subscribing
       --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.
       -v             Print messages verbosely, showing the topic name.
       -V             Print messages verbosely, showing current time and the topic name.
+      --cport <port> Source port for outgoing packets. Uses port in ephemeral range if not specified or set to 0.
 
 
 Dumping
@@ -112,6 +114,7 @@ or MQTT-SN gateway.
       -h <host>      MQTT-SN host to connect to. Defaults to '127.0.0.1'.
       -p <port>      Network port to connect to. Defaults to 1883.
       --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.
+      --cport <port> Source port for outgoing packets. Uses port in ephemeral range if not specified or set to 0.
 
 
 License

--- a/mqtt-sn-pub.c
+++ b/mqtt-sn-pub.c
@@ -42,6 +42,7 @@ const char *message_data = NULL;
 const char *message_file = NULL;
 const char *mqtt_sn_host = "127.0.0.1";
 const char *mqtt_sn_port = MQTT_SN_DEFAULT_PORT;
+uint16_t source_port = 0;
 uint16_t topic_id = 0;
 uint8_t topic_id_type = MQTT_SN_TOPIC_TYPE_NORMAL;
 uint16_t keep_alive = MQTT_SN_DEFAULT_KEEP_ALIVE;
@@ -73,6 +74,7 @@ static void usage()
     fprintf(stderr, "  -T <topicid>   Pre-defined MQTT-SN topic ID to publish to.\n");
     fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n");
     fprintf(stderr, "  --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.\n");
+    fprintf(stderr, "  --cport <port> Source port for outgoing packets. Uses port in ephemeral range if not specified or set to %d.\n", source_port);
     exit(EXIT_FAILURE);
 }
 
@@ -83,6 +85,7 @@ static void parse_opts(int argc, char** argv)
     {
         {"fe",    no_argument,       0, 1000 },
         {"wlnid", required_argument, 0, 1001 },
+        {"cport", required_argument, 0, 1002 },
         {0, 0, 0, 0}
     };
 
@@ -162,6 +165,10 @@ static void parse_opts(int argc, char** argv)
 
         case 1001:
             mqtt_sn_set_frwdencap_parameters((uint8_t*)optarg, strlen(optarg));
+            break;
+
+        case 1002:
+            source_port = atoi(optarg);
             break;
 
         case '?':
@@ -263,7 +270,7 @@ int main(int argc, char* argv[])
     mqtt_sn_set_timeout(keep_alive / 2);
 
     // Create a UDP socket
-    sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port);
+    sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port, source_port);
     if (sock) {
         // Connect to gateway
         if (qos >= 0) {

--- a/mqtt-sn-serial-bridge.c
+++ b/mqtt-sn-serial-bridge.c
@@ -47,6 +47,7 @@
 const char *mqtt_sn_host = "127.0.0.1";
 const char *mqtt_sn_port = MQTT_SN_DEFAULT_PORT;
 const char *serial_device = NULL;
+uint16_t source_port = 0;
 speed_t serial_baud = B9600;
 uint8_t debug = 0;
 uint8_t frwdencap = FALSE;
@@ -64,6 +65,7 @@ static void usage()
     fprintf(stderr, "  -h <host>      MQTT-SN host to connect to. Defaults to '%s'.\n", mqtt_sn_host);
     fprintf(stderr, "  -p <port>      Network port to connect to. Defaults to %s.\n", mqtt_sn_port);
     fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n");
+    fprintf(stderr, "  --cport <port> Source port for outgoing packets. Uses port in ephemeral range if not specified or set to %d.\n", source_port);
     exit(EXIT_FAILURE);
 }
 
@@ -73,6 +75,7 @@ static void parse_opts(int argc, char** argv)
     static struct option long_options[] =
     {
         {"fe",    no_argument,       0, 1000 },
+        {"cport", required_argument, 0, 1001 },
         {0, 0, 0, 0}
     };
 
@@ -104,6 +107,10 @@ static void parse_opts(int argc, char** argv)
             mqtt_sn_enable_frwdencap();
             frwdencap = TRUE;
             break;
+        case 1001:
+            source_port = atoi(optarg);
+            break;
+
         case '?':
         default:
             usage();
@@ -272,7 +279,7 @@ int main(int argc, char* argv[])
     signal(SIGHUP, termination_handler);
 
     // Create a UDP socket
-    sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port);
+    sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port, source_port);
 
     // Open the serial port
     fd = serial_open(serial_device);

--- a/mqtt-sn-sub.c
+++ b/mqtt-sn-sub.c
@@ -51,6 +51,7 @@ uint16_t predef_topic_id_index = 0;
 #define ARRAY_INCREMENT 10
 const char *mqtt_sn_host = "127.0.0.1";
 const char *mqtt_sn_port = MQTT_SN_DEFAULT_PORT;
+uint16_t source_port = 0;
 uint16_t keep_alive = MQTT_SN_DEFAULT_KEEP_ALIVE;
 uint16_t sleep_duration = 0;
 int8_t qos = 0;
@@ -79,6 +80,7 @@ static void usage()
     fprintf(stderr, "  -T <topicid>   Pre-defined MQTT-SN topic ID to subscribe to. It may repeat multiple times.\n");
     fprintf(stderr, "  --fe           Enables Forwarder Encapsulation. Mqtt-sn packets are encapsulated according to MQTT-SN Protocol Specification v1.2, chapter 5.5 Forwarder Encapsulation.\n");
     fprintf(stderr, "  --wlnid        If Forwarder Encapsulation is enabled, wireless node ID for this client. Defaults to process id.\n");
+    fprintf(stderr, "  --cport <port> Source port for outgoing packets. Uses port in ephemeral range if not specified or set to %d.\n", source_port);
     fprintf(stderr, "  -v             Print messages verbosely, showing the topic name.\n");
     fprintf(stderr, "  -V             Print messages verbosely, showing current time and the topic name.\n");
     exit(EXIT_FAILURE);
@@ -91,6 +93,7 @@ static void parse_opts(int argc, char** argv)
     {
         {"fe",    no_argument,       0, 1000 },
         {"wlnid", required_argument, 0, 1001 },
+        {"cport", required_argument, 0, 1002 },
         {0, 0, 0, 0}
     };
 
@@ -163,6 +166,10 @@ static void parse_opts(int argc, char** argv)
             mqtt_sn_set_frwdencap_parameters((uint8_t*)optarg, strlen(optarg));
             break;
 
+        case 1002:
+            source_port = atoi(optarg);
+            break;
+
         case 'v':
             // Prevent -v setting verbose level back down to 1 if already set to 2 by -V
             verbose = (verbose == 0) ? 1 : verbose;
@@ -222,7 +229,7 @@ int main(int argc, char* argv[])
     signal(SIGHUP, termination_handler);
 
     // Create a UDP socket
-    sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port);
+    sock = mqtt_sn_create_socket(mqtt_sn_host, mqtt_sn_port, source_port);
     if (sock) {
         // Connect to server
         mqtt_sn_log_debug("Connecting...");

--- a/mqtt-sn.h
+++ b/mqtt-sn.h
@@ -190,7 +190,7 @@ typedef struct topic_map {
 
 
 // Library functions
-int mqtt_sn_create_socket(const char* host, const char* port);
+int mqtt_sn_create_socket(const char* host, const char* port, uint16_t source_port);
 void mqtt_sn_send_connect(int sock, const char* client_id, uint16_t keepalive, uint8_t clean_session);
 void mqtt_sn_send_register(int sock, const char* topic_name);
 void mqtt_sn_send_publish(int sock, uint16_t topic_id, uint8_t topic_type, const void* data, uint16_t data_len, int8_t qos, uint8_t retain);


### PR DESCRIPTION
Some funny networks might require users to use only a narrow range of ports... or even only one port as a source port. This patch adds --cport flag to support setting the source port in the UDP packets via binding the client socket to the specified address.

Please test this PR before merging and report about any issues.