### PR TITLE
Bugfix: Use msg ID 0 for QoS levels < 1

### DIFF
--- a/mqtt-sn.c
+++ b/mqtt-sn.c
@@ -439,7 +439,11 @@ void mqtt_sn_send_publish(int sock, uint16_t topic_id, uint8_t topic_type, const
     packet.flags += mqtt_sn_get_qos_flag(qos);
     packet.flags += (topic_type & 0x3);
     packet.topic_id = htons(topic_id);
-    packet.message_id = htons(next_message_id++);
+    if (qos > 0) {
+        packet.message_id = htons(next_message_id++);
+    } else {
+        packet.message_id = 0x0000;
+    }
     memcpy(packet.data, data, sizeof(packet.data));
     packet.length = 0x07 + data_len;
 

--- a/test/mqtt-sn-pub-test.rb
+++ b/test/mqtt-sn-pub-test.rb
@@ -148,6 +148,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('test_publish_qos_n1', @packet.data)
     assert_equal(-1, @packet.qos)
     assert_equal(false, @packet.retain)
+    assert_equal(0, @packet.id)
   end
 
   def test_publish_debug
@@ -366,6 +367,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('test_publish_qos_0', @packet.data)
     assert_equal(0, @packet.qos)
     assert_equal(false, @packet.retain)
+    assert_equal(0, @packet.id)
   end
 
   def test_publish_qos_0_short
@@ -388,6 +390,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('test_publish_qos_0_short', @packet.data)
     assert_equal(0, @packet.qos)
     assert_equal(false, @packet.retain)
+    assert_equal(0, @packet.id)
   end
 
   def test_publish_qos_0_predefined
@@ -410,6 +413,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('test_publish_qos_0_predefined', @packet.data)
     assert_equal(0, @packet.qos)
     assert_equal(false, @packet.retain)
+    assert_equal(0, @packet.id)
   end
 
   def test_publish_qos_0_retained
@@ -432,6 +436,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('test_publish_retained', @packet.data)
     assert_equal(0, @packet.qos)
     assert_equal(true, @packet.retain)
+    assert_equal(0, @packet.id)
   end
 
   def test_publish_qos_0_empty
@@ -453,6 +458,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('', @packet.data)
     assert_equal(0, @packet.qos)
     assert_equal(true, @packet.retain)
+    assert_equal(0, @packet.id)
   end
 
   def test_publish_qos_1
@@ -475,6 +481,7 @@ class MqttSnPubTest < Minitest::Test
     assert_equal('test_publish_qos_1', @packet.data)
     assert_equal(1, @packet.qos)
     assert_equal(false, @packet.retain)
+    assert_equal(2, @packet.id) # REGISTER for topic ID has id 1
   end
 
   def test_publish_qos_1_puback_timeout


### PR DESCRIPTION
`mqtt-sn-pub` used non-zero message IDs regardless of the QoS level, while the specification states:

> MsgId: same meaning as the MQTT “Message ID”; only relevant in case of QoS levels 1 and 2, otherwise
coded 0x0000.

(page 14)